### PR TITLE
correcting function name as per builder of ConvolutionalNetwork

### DIFF
--- a/VisualRecognitionAPI/src/main/java/visrec/impl/deepnetts/DeepNettsImageClassifier.java
+++ b/VisualRecognitionAPI/src/main/java/visrec/impl/deepnetts/DeepNettsImageClassifier.java
@@ -120,8 +120,8 @@ public class DeepNettsImageClassifier extends AbstractImageClassifier<BufferedIm
                                         .addFullyConnectedLayer(30, ActivationType.RELU)
                                         .addFullyConnectedLayer(20, ActivationType.RELU)
                                         .addOutputLayer(classCount, SoftmaxOutputLayer.class)
-                                        .withLossFunction(CrossEntropyLoss.class)
-                                        .withRandomSeed(123)       
+                                        .lossFunction(CrossEntropyLoss.class)
+                                        .randomSeed(123)
                                         .build();  
 
         LOGGER.info("Done!");       


### PR DESCRIPTION
Either builder, FilesIO and TrainDeepNetts have to be changed to have the method names for randomSeed and lossFunction as withRandomSeed or withLossFunction. Or, we have to change in this one file. 